### PR TITLE
Feature get dataref

### DIFF
--- a/XplaneServer/src/Datarefs/Dataref.cpp
+++ b/XplaneServer/src/Datarefs/Dataref.cpp
@@ -393,6 +393,10 @@ void Dataref::FromJson(json data)
 	{
 		m_logger.Log("Dataref: '" + m_link + "' is READONLY", Logger::Severity::WARNING);
 	}
+	if(!data.contains("Type"))
+	{
+		this->LoadType();
+	}
 	if(data.contains("Value"))
 	{
 		//check if type is string or int/float/json

--- a/XplaneServer/src/Datarefs/DatarefManager.cpp
+++ b/XplaneServer/src/Datarefs/DatarefManager.cpp
@@ -69,7 +69,6 @@ void Callback(double step, void* tag)
         case OperationsEnum::GetData:
         {
             cm->GetLogger().Log("Getting dataref");
-            m.message["Result"] = "NotImplemented";
             if (!m.message.contains("Dataref")) {
                 m.message["Result"] = "Error:Missing Dataref entry in JSON";
                 continue;

--- a/XplaneServer/src/Datarefs/DatarefManager.cpp
+++ b/XplaneServer/src/Datarefs/DatarefManager.cpp
@@ -67,9 +67,30 @@ void Callback(double step, void* tag)
             break;
         }
         case OperationsEnum::GetData:
+        {
             cm->GetLogger().Log("Getting dataref");
             m.message["Result"] = "NotImplemented";
+            if (!m.message.contains("Dataref")) {
+                m.message["Result"] = "Error:Missing Dataref entry in JSON";
+                continue;
+            }
+            std::string link = m.message["Dataref"]["Link"].get<std::string>();
+            AbstractDataref* d;
+            if (cm->isFF320Api() &&
+                link.find("Aircraft") != std::string::npos &&
+                link.find(".") != std::string::npos)
+            {
+                d = new FFDataref(cm->GetFF320Interface());
+            }
+            else {
+                d = new Dataref();
+            }
+            d->FromJson(m.message["Dataref"]);
+            std::string value = d->GetValue();
+            m.message["Dataref"]["Value"] = value;
+            m.message["Result"] = "Ok";
             break;
+        }
         case OperationsEnum::RegisterData:
             cm->GetLogger().Log("Registering dataref");
             m.message["Result"] = "NotImplemented";

--- a/XplaneTester/main.py
+++ b/XplaneTester/main.py
@@ -4,10 +4,15 @@ import json
 sim = ("0.0.0.0", 50555)
 
 ops = {
-    "Operation" : "setdata",
-    "Link" : "sim/weather/rain_percent",
-    "Value": "1.0"
+    "Dataref" : {
+        "Link" : "sim/flightmodel/position/latitude",
+        "Type" : "DOUBLE"
+    },
+    "Operation" : "getdata"
 }
 
 so = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+so.bind(("0.0.0.0", 55_876))
 so.sendto(json.dumps(ops).encode(), sim)
+print(so.recvfrom(1024)[0].decode())


### PR DESCRIPTION
Get dataref via the **GetData** command.

Required Parameters:
- **Operation** : _GetData_
- **Dataref** : The required dataref (should implement **Link** and could implement (optional) _ConversionFactor_ and _Type_  **DO NOT SET/ADD THE VALUE FIELD**

Return : 
The same message with the **VALUE** field in **Dataref**

Close #3 